### PR TITLE
Update WhoisClient.php - avoid dynamic property

### DIFF
--- a/src/WhoisClient.php
+++ b/src/WhoisClient.php
@@ -52,6 +52,9 @@ class WhoisClient
     /** @var int Communications timeout */
     public $stimeout = 10;
 
+    /** @var WhoisClient */
+    public $deepWhois;
+
     /** @var string[] List of servers and handlers (loaded from servers.whois) */
     public $DATA = array();
 


### PR DESCRIPTION
Resolves the deprecation notice in #10 and other similar notices.

(e.g. `PHP Deprecated:  Creation of dynamic property gtld_handler::$deepWhois is deprecated in
vendor/kevinoo/phpwhois/src/WhoisClient.php on line 492`).